### PR TITLE
Standardize function naming conventions in requirements

### DIFF
--- a/requirements/shared/zsh_scripting/zsh_core_scripting.md
+++ b/requirements/shared/zsh_scripting/zsh_core_scripting.md
@@ -76,7 +76,12 @@ setopt errexit nounset pipefail localoptions warncreateglobal
 
 ### Naming Conventions
 - **Scripts:** Use `lower_snake_case.sh` (not `.zsh`) in `verb_preposition_object.sh` order (e.g., `create_inception_commit.sh`).
+- **Library Scripts:** Use `_Library_Name.zsh` format with leading underscore to indicate it's not meant to be executed directly (e.g., `_Z_Utils.zsh`).
 - **Functions:** Use `lowerfirst_Pascal_Snake_Case` in `verb_Preposition_Object` order (e.g., `verify_Commit_Signature()`).
+  - First word should be lowercase, subsequent words capitalized
+  - Use at least two words to clearly convey purpose: prefer `display_Script_Usage()` over `display_Usage()`
+  - Use descriptive verbs that indicate precise action: `execute_Core_Workflow()` rather than `core_Logic()`
+  - The `main()` function is an exception to this convention, following broader Zsh standards
   - To prevent potential conflicts with Zsh built-ins and plugins, check for existing function names using `typeset -f function_name` during testing.
 - **Variables:**
   - **Avoid globals:** Use script-scoped variables instead.
@@ -105,17 +110,23 @@ typeset -r SCRIPT_VERSION="1.0.0"
 Good - Clear verb_Object pattern with purpose:
 ```zsh
 calculate_File_Hash()     # Calculates hash of a file
-verify_Git_Repo()        # Verifies Git repository status
+verify_Git_Repo()         # Verifies Git repository status
 parse_Command_Options()   # Parses command line options
 validate_Input_Path()     # Validates an input path exists
+display_Script_Usage()    # Displays script usage information
+execute_Core_Workflow()   # Executes the script's primary workflow
+parse_CLI_Options()       # Parses command-line interface options
 ```
 
-Bad - Unclear purpose or missing verb:
+Bad - Unclear purpose, missing verb, or single-word objects:
 ```zsh
-do_hash()          # Unclear what is being hashed
-repo_check()       # Missing verb, unclear action
-args()            # Too generic, unclear purpose
-validate()         # Missing object being validated
+do_hash()               # Unclear what is being hashed
+repo_check()            # Missing verb, unclear action
+args()                  # Too generic, unclear purpose
+validate()              # Missing object being validated
+display_Usage()         # Single-word object lacks specificity 
+core_Logic()            # "Logic" is vague, not a clear object
+parse_Arguments()       # "Arguments" could be any kind of arguments (function or CLI)
 ```
 
 ## Zsh Core Scripting - Execution Flow and Structure

--- a/requirements/shared/zsh_scripting/zsh_framework_scripting.md
+++ b/requirements/shared/zsh_scripting/zsh_framework_scripting.md
@@ -120,19 +120,19 @@ Script Invocation
     │   └── Check dependencies, requirements, and environment
     │
     ├── Two-Phase Argument Processing:
-    │   ├── Phase 1: z_Parse_Initial_Arguments
-    │   │   ├── Process framework arguments (--verbose, --debug, etc.)
+    │   ├── Phase 1: z_Parse_CLI_Initial_Options
+    │   │   ├── Process framework options (--verbose, --debug, etc.)
     │   │   └── Set global execution flags
     │   │
-    │   └── Phase 2: parse_Remaining_Arguments
-    │       ├── Process domain-specific arguments
+    │   └── Phase 2: parse_CLI_Remaining_Options
+    │       ├── Process domain-specific options
     │       ├── Call handle_* functions for complex arguments
     │       │   ├── handle_Change_Directory for -C/--chdir
     │       │   ├── handle_Process_Config for config options
     │       │   └── Other specialized handlers as needed
     │       └── Validate argument combinations
     │
-    └── core_Logic()
+    └── execute_Core_Workflow()
         ├── High-level workflow orchestration
         │   ├── Phase initialization and sequencing
         │   ├── Workflow state management
@@ -182,7 +182,7 @@ Domain Function Error
 │   │   └── OR abort current phase
 │   └── Return error status to controller
 │
-├── Controller Layer (core_Logic)
+├── Controller Layer (execute_Core_Workflow)
 │   ├── Phase failure detection
 │   ├── Error aggregation
 │   ├── Result generation with error context
@@ -198,16 +198,16 @@ This error flow ensures errors are detected as close to their source as possible
 
 ### Two-Phase Argument Processing
 
-Framework scripts must implement a two-phase argument processing approach:
+Framework scripts must implement a two-phase CLI option processing approach:
 
-1. **Framework Argument Phase**:
-   - Process framework-level arguments first (verbose, debug, etc.)
-   - Must use a dedicated function such as `z_Parse_Initial_Arguments`
+1. **Framework Options Phase**:
+   - Process framework-level options first (verbose, debug, etc.)
+   - Must use a dedicated function such as `z_Parse_CLI_Initial_Options`
    - Sets global execution flags that affect script behavior
 
-2. **Domain Argument Phase**:
-   - Process domain-specific arguments after framework setup
-   - Must use a separate function such as `parse_Remaining_Arguments`
+2. **Domain Options Phase**:
+   - Process domain-specific options after framework setup
+   - Must use a separate function such as `parse_CLI_Remaining_Options`
    - Applies domain logic to specialized parameters
 
 ### Controller Function Responsibilities
@@ -217,12 +217,12 @@ Framework scripts must clearly delineate responsibilities between controller fun
 - **main()**: Script entry point that:
   - Sets up signal handlers and traps
   - Initializes the environment
-  - Processes command-line arguments (via two-phase approach)
-  - Delegates to `core_Logic` for main workflow
+  - Processes command-line options (via two-phase approach)
+  - Delegates to `execute_Core_Workflow` for main workflow
   - Ensures proper cleanup and exit status propagation
   - Must be the only function that directly exits the script
 
-- **core_Logic()**: Main workflow orchestrator that:
+- **execute_Core_Workflow()**: Main workflow orchestrator that:
   - Manages the execution sequence
   - Coordinates phase transitions
   - Controls workflow branching
@@ -272,7 +272,7 @@ Follow the "Naming and Documentation Requirements" in `REQUIREMENTS-Zsh_Core_Scr
 
 - **Controller Functions**:
   - Standardized names without prefix
-  - Examples: `main`, `core_Logic`
+  - Examples: `main`, `execute_Core_Workflow`
 
 ### Comprehensive Function Documentation
 
@@ -670,7 +670,7 @@ Framework scripts must implement comprehensive system requirements validation:
 
 Example dependency checking:
 ```zsh
-function check_External_Dependency() {
+function check_External_Tool_Dependency() {
     typeset DependencyName="$1"
     typeset MinVersion="${2:-}"
     typeset Required="${3:-$TRUE}"

--- a/requirements/shared/zsh_scripting/zsh_snippet_scripting.md
+++ b/requirements/shared/zsh_scripting/zsh_snippet_scripting.md
@@ -87,14 +87,14 @@ Script Start
 │       └── Call main()
 │
 └── main()
-    └── core_Logic()
+    └── execute_Core_Workflow()
         └── [Success] ──► stdout
 ```
 
 #### Simple Error Propagation (Failure Path)
 
 ```
-core_Logic()
+execute_Core_Workflow()
 └── return error (Exit_Status_Code)
     └── main()
         ├── exit (with status)
@@ -111,7 +111,7 @@ emulate -LR zsh
 setopt errexit nounset pipefail localoptions warncreateglobal
 
 # Function for core logic
-core_Logic() {
+execute_Core_Workflow() {
     # Primary functionality code
     # Return appropriate exit status
 }
@@ -119,7 +119,7 @@ core_Logic() {
 # Main execution block
 main() {
     # Parameter and dependency checks
-    core_Logic "$@"
+    execute_Core_Workflow "$@"
 }
 
 # Execute only if run directly
@@ -143,13 +143,13 @@ Script Start
 │       └── Call main()
 │
 └── main()
-    ├── parse_Parameters()
+    ├── parse_CLI_Options()
     │   └── validate input
     │
-    ├── check_Dependencies() (optional)
-    │   └── verify commands
+    ├── check_Script_Dependencies() (optional)
+    │   └── check commands
     │
-    └── core_Logic()
+    └── execute_Core_Workflow()
         └── [Success] ──► stdout
 ```
 
@@ -162,13 +162,13 @@ core_Logic()
         ├── exit (with status)
         └── [Error] ──► stderr
 
-parse_Parameters()
-└── show_Usage()
+parse_CLI_Options()
+└── display_Script_Usage()
     └── main()
         ├── exit (Exit_Status_Usage)
         └── [Error] ──► stderr
 
-check_Dependencies()
+check_Script_Dependencies()
 └── return error (Exit_Status_Dependency)
     └── main()
         ├── exit (with status)
@@ -194,7 +194,7 @@ typeset -r Exit_Status_Usage=2
 
 # Remaining script-scoped variables here
 
-show_Usage() {
+display_Script_Usage() {
    # Prints usage instructions
 }
 
@@ -204,28 +204,28 @@ other_Function() {
     # Return appropriate exit status on error
 }
 
-core_Logic() {
+execute_Core_Workflow() {
    # Primary script functionality
    # Call other functions as needed
    # Return appropriate exit status
 }
 
-check_Dependencies() {
-   # Verify required commands exist
+check_Script_Dependencies() {
+   # Check for required commands and resources
    # Return appropriate exit status on failure
 }
 
-parse_Parameters() {
-   # Process and validate input parameters
-   # Call show_Usage() for invalid input
-   # Return validated parameters
+parse_CLI_Options() {
+   # Process and validate command-line options
+   # Call display_Script_Usage() for invalid input
+   # Return validated options
 }
 
 main() {
    # Orchestrate execution flow
-   # 1. Parse parameters
-   # 2. Check dependencies (if needed)
-   # 3. Execute core logic
+   # 1. Parse CLI options
+   # 2. Check script dependencies (if needed)
+   # 3. Execute core workflow
 }
 
 # Execute only when run directly

--- a/src/examples/snippet_template.sh
+++ b/src/examples/snippet_template.sh
@@ -27,7 +27,7 @@ typeset -r Exit_Status_IO=3                 # Input/output error
 typeset -r Exit_Status_Format=4             # Invalid format specified
 
 #----------------------------------------------------------------------#
-# Function: show_Usage
+# Function: display_Script_Usage
 #----------------------------------------------------------------------#
 # Description:
 #   Prints usage instructions and examples to stderr
@@ -36,7 +36,7 @@ typeset -r Exit_Status_Format=4             # Invalid format specified
 # Returns:
 #   Does not return - exits with Exit_Status_Usage
 #----------------------------------------------------------------------#
-show_Usage() {
+display_Script_Usage() {
     print -u2 "Usage: $0 [-f|--format default|json|yaml] <file>
 Examples:
   $0 ~/.zshrc             # Show status in default format
@@ -131,7 +131,7 @@ get_File_Status() {
 }
 
 #----------------------------------------------------------------------#
-# Function: core_Logic
+# Function: execute_Core_Workflow
 #----------------------------------------------------------------------#
 # Description:
 #   Main processing function
@@ -143,7 +143,7 @@ get_File_Status() {
 #   Exit_Status_IO on file access error
 #   Exit_Status_Format on invalid format
 #----------------------------------------------------------------------#
-core_Logic() {
+execute_Core_Workflow() {
     typeset Format="$1" FilePath="$2"
     typeset Status StatusArray
     
@@ -160,10 +160,10 @@ core_Logic() {
 }
 
 #----------------------------------------------------------------------#
-# Function: parse_Parameters
+# Function: parse_CLI_Options
 #----------------------------------------------------------------------#
 # Description:
-#   Processes command line arguments
+#   Processes command line options
 # Parameters:
 #   $@ - Command line arguments
 # Returns:
@@ -171,23 +171,23 @@ core_Logic() {
 #   Exit_Status_Success on success
 #   Exit_Status_Usage on invalid arguments
 #----------------------------------------------------------------------#
-parse_Parameters() {
+parse_CLI_Options() {
     typeset Format="default"
     typeset FilePath=""
     
     while (( $# > 0 )); do
         case "$1" in
             -f|--format)
-                (( $# > 1 )) || show_Usage
+                (( $# > 1 )) || display_Script_Usage
                 Format="$2"
                 shift 2
                 ;;
             -h|--help)
-                show_Usage
+                display_Script_Usage
                 ;;
             -*)
                 print -u2 "Error: Unknown option '$1'"
-                show_Usage
+                display_Script_Usage
                 ;;
             *)
                 FilePath="$1"
@@ -197,14 +197,14 @@ parse_Parameters() {
         esac
     done
     
-    [[ -n "$FilePath" ]] || show_Usage
+    [[ -n "$FilePath" ]] || display_Script_Usage
     
     print -- "$Format $FilePath"
     return $Exit_Status_Success
 }
 
 #----------------------------------------------------------------------#
-# Function: check_Dependencies
+# Function: check_Script_Dependencies
 #----------------------------------------------------------------------#
 # Description:
 #   Verifies required external commands are available
@@ -216,7 +216,7 @@ parse_Parameters() {
 # Dependencies:
 #   Requires stat command with BSD-style arguments
 #----------------------------------------------------------------------#
-check_Dependencies() {
+check_Script_Dependencies() {
     # Check for stat command
     command -v stat >/dev/null || {
         print -u2 "Error: Required command 'stat' not found"
@@ -237,6 +237,7 @@ check_Dependencies() {
 #----------------------------------------------------------------------#
 # Description:
 #   Script entry point
+#   Note: This function name is kept as 'main' to conform with broader Zsh scripting standards
 # Parameters:
 #   $@ - Command line arguments
 # Returns:
@@ -247,14 +248,14 @@ main() {
     typeset Params Format FilePath
     
     # Check dependencies first
-    check_Dependencies || exit $?
+    check_Script_Dependencies || exit $?
     
-    # Get and parse parameters
-    Params=$(parse_Parameters "$@") || exit $?
+    # Get and parse CLI options
+    Params=$(parse_CLI_Options "$@") || exit $?
     read -r Format FilePath <<< "$Params"
     
-    # Execute core logic
-    core_Logic "$Format" "$FilePath" || exit $?
+    # Execute core workflow
+    execute_Core_Workflow "$Format" "$FilePath" || exit $?
     
     exit $Exit_Status_Success
 }


### PR DESCRIPTION
## Summary
- Add Library Scripts naming guidelines to core scripting requirements
- Update function naming examples with clearer, multi-word patterns 
- Standardize CLI option handling with consistent naming (`parse_CLI_Options`)
- Rename core workflow functions to `execute_Core_Workflow`
- Update snippet template to demonstrate new naming conventions
- Document `main()` as exception to naming conventions

## Test plan
- Verify requirements documents are consistent
- Check that snippet template follows new guidelines
- Ensure framework script guidelines use consistent pattern for option parsing